### PR TITLE
added namespace appearanceMember

### DIFF
--- a/src/Data/cityGML.js
+++ b/src/Data/cityGML.js
@@ -16,6 +16,9 @@ CityGL.CityGML.prototype.Read= function(){
 		var extent = this.ParseExtent(this.doc);
 		//get the appearances
 		var apps =  this.doc.getElementsByTagNameNS(this.app, 'appearance');
+		if (0 == apps.length) {
+			apps =  this.doc.getElementsByTagNameNS(this.app, 'appearanceMember');
+		}
 		var appearances = this.ParseAppearance(apps);
 		var buildings = this.doc.getElementsByTagNameNS(this.bldg, 'Building');
 		


### PR DESCRIPTION
The Berlin CityGML (version 2.0) uses the appearanceMember instead of
appearance namespace
